### PR TITLE
Add MCP server support and improve documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,8 @@ telecode/
 │   ├── server.py          # FastAPI webhook server (main logic)
 │   ├── telegram.py        # Telegram API client
 │   ├── claude.py          # Claude Code integration
-│   └── codex.py           # Codex integration
+│   ├── codex.py           # Codex integration
+│   └── mcp_server.py      # MCP server (Model Context Protocol)
 ├── tests/                  # Test suite
 │   └── test_server_messages.py
 ├── pyproject.toml         # Project metadata and build config
@@ -74,6 +75,7 @@ telecode/
 - `TELECODE_PORT` - Server port (default: `8000`)
 - `TELECODE_ALLOWED_USERS` - Access control (comma-separated IDs/@usernames)
 - `TELECODE_VERBOSE` - Enable verbose logging (`1`)
+- `TELECODE_ENABLE_MCP` - Enable MCP server (`1`)
 - `TELECODE_NGROK` - Enable/disable ngrok auto-start (`0`/`1`)
 - `NGROK_AUTHTOKEN` - ngrok authentication token
 - `TELECODE_TTS` - Enable TTS responses (`1`)
@@ -204,6 +206,37 @@ echo {prompt} | codex exec [--image {path}]...
 
 **Running Tests:** `pytest -q`
 
+### 7. `mcp_server.py` - MCP Server (Model Context Protocol)
+
+**Purpose:** Exposes telecode tools via MCP protocol for remote AI agent access.
+
+**Key Features:**
+- Three MCP tools: `local_claude_code`, `local_codex`, `local_cli`
+- Independent session management (separate from Telegram sessions)
+- Thread-safe with dedicated `_MCP_SESSION_LOCK`
+- Runs on same port as Telegram webhook (shares FastAPI app)
+
+**Function:** `create_mcp_app()` - Returns ASGI app from `mcp.http_app(path="/")`
+
+**Critical Implementation Details:**
+- **MUST call `.http_app()`** on FastMCP instance to get ASGI app (not directly mountable)
+- **MUST integrate lifespan:** Enter/exit `mcp_app.lifespan()` context in FastAPI's `_lifespan()` function
+- **Path parameter:** Use `path="/"` to avoid double paths (prevents `/mcp/mcp/` issue)
+- **Expected responses:** HTTP 406 "Not Acceptable" when accessed without `Accept: text/event-stream` header (correct behavior)
+
+**Testing with pipx:**
+```bash
+# After code changes, reinstall to pick up edits
+pipx install --force .
+
+# Start with MCP enabled
+TELECODE_ENABLE_MCP=1 TELEGRAM_BOT_TOKEN=test telecode --enable-mcp --no-ngrok -v
+
+# Test endpoint (should return JSON-RPC error about SSE headers)
+curl -sL http://localhost:8000/mcp/
+# Expected: {"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Not Acceptable: Client must accept text/event-stream"}}
+```
+
 ## Development Setup
 
 ### 1. Initial Setup
@@ -305,6 +338,282 @@ pytest tests/test_server_messages.py::test_handle_text_message_calls_prompt
 - **Thread safety** - Global and per-session locks prevent race conditions
 - **Background processing** - Telegram webhooks return immediately, processing happens async
 - **Graceful degradation** - Missing optional features (Whisper, TTS) don't break core functionality
+
+## Local Testing for AI Agents
+
+This section provides step-by-step instructions for AI assistants to test the telecode server locally without requiring Telegram or external services.
+
+### Prerequisites for Testing
+
+```bash
+# Ensure dependencies are installed
+pip install -r requirements.txt
+
+# Or install the package in development mode
+pip install -e .
+```
+
+### Quick Test: Start Server and Verify Endpoints
+
+**Step 1: Start the server with minimal configuration**
+
+```bash
+# Set required environment variables (no real Telegram needed for basic testing)
+export TELEGRAM_BOT_TOKEN="test_token_for_local_testing"
+export TELEGRAM_TUNNEL_URL="http://localhost:8000"
+export TELECODE_VERBOSE=1
+export TELECODE_ENABLE_MCP=1
+
+# Start server on localhost:8000
+python3 -c "
+import subprocess
+import sys
+import time
+
+# Start server in background
+proc = subprocess.Popen(
+    [sys.executable, '-m', 'uvicorn', 'telecode.server:app',
+     '--host', '0.0.0.0', '--port', '8000', '--log-level', 'info'],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+    env={
+        'TELEGRAM_BOT_TOKEN': 'test_token',
+        'TELEGRAM_TUNNEL_URL': 'http://localhost:8000',
+        'TELECODE_VERBOSE': '1',
+        'TELECODE_ENABLE_MCP': '1',
+        **dict(subprocess.os.environ)
+    }
+)
+
+# Wait for server to start
+time.sleep(3)
+
+print('Server started, PID:', proc.pid)
+print('Run your tests, then kill process:', proc.pid)
+" &
+
+# Save the PID
+SERVER_PID=$!
+echo "Server PID: $SERVER_PID"
+sleep 3
+```
+
+**Step 2: Test basic endpoints**
+
+```bash
+# Test 1: Health check endpoint
+echo "=== Test 1: Health Check ==="
+curl -v http://localhost:8000/health
+echo -e "\n"
+
+# Test 2: MCP test endpoint (requires MCP enabled)
+echo "=== Test 2: MCP Test Endpoint ==="
+curl -v http://localhost:8000/mcp-test
+echo -e "\n"
+
+# Expected responses:
+# Test 1: {"ok": true}
+# Test 2: {"status": "ok", "mcp_enabled": true, ...}
+```
+
+**Step 3: Check server logs for verbose output**
+
+When TELECODE_VERBOSE=1, you should see logs like:
+```
+Debug: TELECODE_VERBOSE = 1
+Debug: Verbose logging = ENABLED
+→ GET /health from 127.0.0.1
+← GET /health → 200 (0.001s)
+```
+
+**Step 4: Clean up**
+
+```bash
+# Kill the server
+kill $SERVER_PID
+```
+
+### Complete Test Script for AI Agents
+
+Use this complete script to test both server startup and endpoints:
+
+```bash
+#!/bin/bash
+# File: test_local_server.sh
+# Purpose: Test telecode server locally without Telegram
+
+set -e
+
+echo "=== Starting Telecode Local Test ==="
+
+# Cleanup function
+cleanup() {
+    echo "Cleaning up..."
+    if [ ! -z "$SERVER_PID" ]; then
+        kill $SERVER_PID 2>/dev/null || true
+    fi
+    rm -f /tmp/telecode_test_output.log
+}
+trap cleanup EXIT
+
+# Start server with test configuration
+echo "Starting server..."
+TELEGRAM_BOT_TOKEN="test_token" \
+TELEGRAM_TUNNEL_URL="http://localhost:8000" \
+TELECODE_VERBOSE=1 \
+TELECODE_ENABLE_MCP=1 \
+python3 -m uvicorn telecode.server:app \
+    --host 0.0.0.0 \
+    --port 8000 \
+    --log-level info \
+    > /tmp/telecode_test_output.log 2>&1 &
+
+SERVER_PID=$!
+echo "Server PID: $SERVER_PID"
+
+# Wait for server to be ready
+echo "Waiting for server to start..."
+sleep 3
+
+# Verify server is running
+if ! kill -0 $SERVER_PID 2>/dev/null; then
+    echo "ERROR: Server failed to start"
+    cat /tmp/telecode_test_output.log
+    exit 1
+fi
+
+echo "Server started successfully!"
+echo ""
+
+# Run tests
+echo "=== Test 1: Health Check ==="
+HEALTH_RESPONSE=$(curl -s http://localhost:8000/health)
+echo "Response: $HEALTH_RESPONSE"
+if echo "$HEALTH_RESPONSE" | grep -q '"ok".*true'; then
+    echo "✓ Health check passed"
+else
+    echo "✗ Health check failed"
+    exit 1
+fi
+echo ""
+
+echo "=== Test 2: MCP Test Endpoint ==="
+MCP_RESPONSE=$(curl -s http://localhost:8000/mcp-test)
+echo "Response: $MCP_RESPONSE"
+if echo "$MCP_RESPONSE" | grep -q '"status".*"ok"'; then
+    echo "✓ MCP test passed"
+else
+    echo "✗ MCP test failed"
+    exit 1
+fi
+echo ""
+
+echo "=== Test 3: Check Verbose Logs ==="
+if grep -q "TELECODE_VERBOSE = 1" /tmp/telecode_test_output.log; then
+    echo "✓ Verbose logging enabled"
+else
+    echo "✗ Verbose logging not found"
+fi
+
+if grep -q "→ GET" /tmp/telecode_test_output.log; then
+    echo "✓ Request logging working"
+else
+    echo "✗ Request logs not found"
+fi
+echo ""
+
+echo "=== Server Logs (last 20 lines) ==="
+tail -20 /tmp/telecode_test_output.log
+echo ""
+
+echo "=== All Tests Passed! ==="
+```
+
+### Testing MCP Server Functionality
+
+To test the MCP server endpoints specifically:
+
+```bash
+# Test MCP endpoint (should return JSON-RPC error about SSE)
+curl -sL http://localhost:8000/mcp/
+# Expected: {"jsonrpc":"2.0","id":"server-error","error":{"code":-32600,"message":"Not Acceptable: Client must accept text/event-stream"}}
+
+# Verify MCP is mounted
+grep "✓ MCP server mounted" /tmp/telecode_test.log
+
+# Expected: HTTP 406 when accessed without proper SSE headers (correct behavior)
+```
+
+### Verifying Verbose Logging
+
+To verify verbose logging is working correctly:
+
+```bash
+# Start server with verbose flag via CLI
+TELEGRAM_BOT_TOKEN=test \
+TELEGRAM_TUNNEL_URL=http://test \
+python3 -m telecode.cli --verbose --enable-mcp --no-ngrok &
+
+SERVER_PID=$!
+sleep 3
+
+# Make a request
+curl http://localhost:8000/health
+
+# Check logs - you should see:
+# Starting server with log_level=info
+# Debug: TELECODE_VERBOSE = 1
+# Debug: Verbose logging = ENABLED
+# → GET /health from 127.0.0.1
+# ← GET /health → 200 (0.XXXs)
+
+# Cleanup
+kill $SERVER_PID
+```
+
+### Expected Behavior Summary
+
+| Endpoint | Method | Expected Response | Status Code |
+|----------|--------|-------------------|-------------|
+| `/health` | GET | `{"ok": true}` | 200 |
+| `/mcp-test` | GET | `{"status": "ok", "mcp_enabled": true, ...}` | 200 |
+| `/mcp/` | GET | JSON-RPC error about SSE headers | 406 |
+| `/telegram/{secret}` | POST | `{"ok": true}` | 200 |
+
+### Troubleshooting Local Tests
+
+**Server won't start:**
+- Check if port 8000 is already in use: `lsof -i :8000`
+- Verify dependencies are installed: `pip list | grep -E "fastapi|uvicorn|fastmcp"`
+- Check for import errors: `python3 -c "from telecode import server"`
+
+**No verbose logs appearing:**
+- Verify TELECODE_VERBOSE is set: `echo $TELECODE_VERBOSE`
+- Check that environment variable is passed to server
+- Look for "Debug: TELECODE_VERBOSE = 1" in startup logs
+
+**MCP endpoints returning 404 or 500:**
+- Verify TELECODE_ENABLE_MCP=1 is set
+- Check for "✓ MCP server mounted at /mcp" in startup logs
+- Ensure fastmcp is installed: `pip show fastmcp`
+- If 500 error about "StreamableHTTPSessionManager not initialized": lifespan not integrated properly
+- If endpoint is at `/mcp/mcp/` instead of `/mcp/`: `path` parameter not set correctly in `http_app()`
+
+### Quick One-Liner Test
+
+For a quick sanity check:
+
+```bash
+# One-liner: Start server, test, and cleanup
+(TELEGRAM_BOT_TOKEN=test TELEGRAM_TUNNEL_URL=http://test TELECODE_VERBOSE=1 python3 -m uvicorn telecode.server:app --host 0.0.0.0 --port 8000 &); sleep 3; curl -s http://localhost:8000/health && curl -s http://localhost:8000/mcp-test; kill %1
+```
+
+Expected output:
+```json
+{"ok":true}
+{"status":"ok","mcp_enabled":false,"message":"If you see this, the server is reachable through ngrok","note":"MCP clients connect to /mcp/ (not this endpoint)"}
+```
 
 ## Common Development Tasks
 
@@ -461,6 +770,7 @@ make release VERSION=0.1.5
 3. **Async vs sync** - Webhook handlers are sync (run in background tasks)
 4. **Image cleanup** - Images in `.telecode_tmp/` are not auto-cleaned
 5. **Error handling** - Always catch exceptions in message handlers
+6. **MCP mounting** - FastMCP requires `.http_app()` call + lifespan integration (see mcp_server.py section)
 
 ### Security Considerations
 
@@ -485,6 +795,9 @@ make release VERSION=0.1.5
 - `httpx` - HTTP client for Telegram API
 - `python-dotenv` - Environment loading (though custom parser used)
 - `ngrok` - Tunnel management
+- `mcp>=1.25.0` - Model Context Protocol SDK
+- `fastmcp>=2.0.0` - FastMCP server framework
+- `websockets<14.0` - WebSocket support for MCP (pinned for compatibility)
 
 **Optional (not in requirements.txt):**
 - `openai-whisper` - Voice transcription

--- a/README.md
+++ b/README.md
@@ -3,615 +3,244 @@
 [![Tests](https://github.com/polinom/telecode/actions/workflows/tests.yml/badge.svg)](https://github.com/polinom/telecode/actions/workflows/tests.yml)
 [![PyPI](https://img.shields.io/pypi/v/telecode.svg)](https://pypi.org/project/telecode/)
 
-**Telecode** is a Telegram webhook server that bridges your Telegram conversations with AI-powered code execution engines (Claude Code and Codex). It allows you to interact with AI assistants directly through Telegram, execute shell commands on your server, process images, transcribe voice messages, and even get text-to-speech audio responses.
+**Your AI Terminal Inside Telegram** — Bridge Telegram with Claude Code and Codex. Execute commands, analyze images, transcribe voice, and chat with AI—all from your favorite messenger.
 
-## Table of Contents
+## ✨ Features
 
-- [Overview](#overview)
-- [Features](#features)
-- [How It Works](#how-it-works)
-  - [Architecture](#architecture)
-  - [Communication Flow](#communication-flow)
-  - [Session Management](#session-management)
-- [Installation](#installation)
-- [Quick Start](#quick-start)
-- [Configuration](#configuration)
-  - [Configuration Files](#configuration-files)
-  - [Configuration Keys](#configuration-keys)
-- [Usage](#usage)
-  - [Telegram Commands](#telegram-commands)
-  - [Text Messages](#text-messages)
-  - [Image Processing](#image-processing)
-  - [Voice Messages](#voice-messages)
-  - [Text-to-Speech (TTS)](#text-to-speech-tts)
-- [Tunnel & Webhook Setup](#tunnel--webhook)
-- [Access Control](#access-control)
-- [Development](#development)
-- [Troubleshooting](#troubleshooting)
-- [License](#license)
+- 🤖 **Dual AI Engines** — Switch between Claude Code and Codex on the fly
+- 📡 **MCP Server** — Expose AI tools via Model Context Protocol for remote agent access
+- 🖼️ **Vision Processing** — Send screenshots and images for AI analysis
+- 🎤 **Voice Transcription** — Whisper-powered voice note transcription
+- 🔊 **Text-to-Speech** — Fish Audio integration for audio responses
+- ⚡ **Real-time Webhooks** — Instant message processing via Telegram webhooks
+- 🔒 **Access Control** — Whitelist users by ID or username
+- 💬 **Persistent Sessions** — Conversations preserved across messages
 
-## Overview
+## 🚀 Quick Start
 
-Telecode creates a bridge between Telegram and AI code execution engines, allowing you to:
-
-- **Chat with AI assistants** (Claude Code or Codex) directly from Telegram
-- **Execute shell commands** on your server remotely
-- **Process images** with vision-capable AI models
-- **Transcribe voice messages** using Whisper
-- **Get audio responses** via text-to-speech (Fish Audio)
-- **Manage persistent conversations** with session tracking
-- **Control access** with user whitelisting
-
-## Features
-
-### Core Features
-
-- **Dual Engine Support**: Switch between Claude Code and Codex engines on-the-fly
-- **Per-Chat Engine Selection**: Different Telegram chats can use different engines
-- **Persistent Sessions**: Conversations are preserved across messages using session IDs
-- **Webhook-Based**: Efficient, real-time message processing via Telegram webhooks
-- **Auto-Tunneling**: Automatic ngrok tunnel creation for local development
-
-### Communication Features
-
-- **Text Messages**: Send prompts and receive AI-generated responses
-- **Image Support**: Send photos or image documents for AI analysis
-- **Voice Messages**: Record voice notes that are automatically transcribed via Whisper
-- **TTS Responses**: Optional text-to-speech audio replies using Fish Audio API
-- **Command Execution**: Run shell commands on the server via `/cli` command
-
-### Security & Control
-
-- **User Whitelisting**: Restrict access by Telegram user ID or username
-- **Webhook Secret**: Secure webhook endpoint with auto-generated secrets
-- **Per-Chat Configuration**: Engine preferences stored per-chat for multi-user scenarios
-
-### Developer Features
-
-- **Verbose Logging**: Detailed console output for debugging
-- **Configuration Management**: Global and local config file support
-- **Auto-Reload**: Development mode with auto-reload capability
-- **Session Locking**: Thread-safe session management for concurrent requests
-
-## How It Works
-
-### Architecture
-
-Telecode is built on a webhook-based architecture using FastAPI:
-
-```
-┌──────────────┐
-│   Telegram   │
-│   Bot API    │
-└──────┬───────┘
-       │ HTTPS Webhook
-       ▼
-┌──────────────────────┐
-│   Public Tunnel      │
-│   (ngrok/custom)     │
-└──────┬───────────────┘
-       │
-       ▼
-┌──────────────────────┐
-│  FastAPI Server      │
-│  (telecode.server)   │
-└──────┬───────────────┘
-       │
-       ├─────────────────┐
-       │                 │
-       ▼                 ▼
-┌─────────────┐   ┌──────────────┐
-│ Claude Code │   │    Codex     │
-│   Engine    │   │   Engine     │
-└─────────────┘   └──────────────┘
-```
-
-### Communication Flow
-
-1. **Message Reception**:
-   - User sends a message in Telegram
-   - Telegram API delivers the message to your webhook endpoint
-   - FastAPI server receives and validates the webhook request
-
-2. **User Authorization**:
-   - Server checks if user is in the allowed list (if configured)
-   - Unauthorized users receive a "Not authorized" message
-
-3. **Message Processing**:
-   - **Text messages**: Checked for commands first, then routed to AI engine
-   - **Voice messages**: Downloaded and transcribed with Whisper, then processed
-   - **Images**: Downloaded to `.telecode_tmp/` and sent to AI with the caption
-   - **Commands**: Executed immediately (e.g., `/cli`, `/engine`, `/tts_on`)
-
-4. **Engine Execution**:
-   - Session lock is acquired to prevent concurrent access
-   - Session ID is retrieved or created for the chat
-   - AI engine is invoked with the prompt and optional image paths
-   - Response is captured and processed
-
-5. **Response Delivery**:
-   - AI response is sent back to Telegram chat
-   - Optional TTS audio is generated and sent if enabled
-   - Session state is persisted for future messages
-
-### Session Management
-
-Telecode maintains conversation context using session IDs:
-
-- **Claude Code**: Sessions are persistent across conversations. Session ID is passed via `--session-id` or `--resume` flags
-- **Codex**: Sessions can be created and resumed, with session IDs extracted from the output
-- **Storage**: Session IDs are stored in `.telecode` file (JSON or key-value format)
-- **Per-Engine**: Separate session IDs for Claude and Codex
-- **Thread-Safe**: Session locks prevent race conditions in multi-user scenarios
-
-### Message Routing
-
-```python
-# Message flow pseudocode
-if message.contains_voice:
-    audio = download_voice(message)
-    text = transcribe_with_whisper(audio)
-    response = send_to_engine(text)
-
-elif message.contains_photo:
-    image_path = download_image(message)
-    response = send_to_engine(caption, images=[image_path])
-
-elif message.contains_text:
-    if is_command(message.text):
-        response = handle_command(message.text)
-    else:
-        response = send_to_engine(message.text)
-
-send_telegram_message(response)
-if tts_enabled:
-    send_telegram_audio(text_to_speech(response))
-```
-
-## Installation
-
-### From PyPI
+### Install
 
 ```bash
 pip install telecode
 ```
 
-### From Source
-
-```bash
-git clone https://github.com/polinom/telecode.git
-cd telecode
-pip install -e .
-```
-
-### Optional Dependencies
-
-For voice message support:
-```bash
-pip install openai-whisper
-```
-
-For TTS support (Fish Audio), ensure you have an API token from [Fish Audio](https://fish.audio).
-
-### System Dependencies
-
-Voice messages require `ffmpeg`:
-
-**macOS**:
-```bash
-brew install ffmpeg
-```
-
-**Ubuntu/Debian**:
-```bash
-sudo apt-get install ffmpeg
-```
-
-**Windows**:
-Download from [ffmpeg.org](https://ffmpeg.org/download.html)
-
-## Quick Start
-
-### 1. Run the Server
-
-Run the server in your project folder (where you have CLAUDE.md or AGENTS.md for AI context):
+### Run
 
 ```bash
 telecode
 ```
 
-On first run, Telecode will prompt you for:
-- **Telegram Bot Token** (from [@BotFather](https://t.me/BotFather))
-- **ngrok Auth Token** (if using auto-tunneling)
+On first run, you'll be prompted for:
+- **Telegram Bot Token** (get it from [@BotFather](https://t.me/BotFather))
+- **ngrok Auth Token** (optional, for auto-tunneling)
 
-Configuration is saved to `./.telecode` or `~/.telecode`.
+That's it! Find your bot in Telegram and start chatting.
 
-### 2. Create a Telegram Bot
+## 📡 MCP Server (NEW)
 
-1. Open Telegram and message [@BotFather](https://t.me/BotFather)
-2. Send `/newbot` and follow the prompts
-3. Copy the bot token (format: `123456789:ABCdefGHIjklMNOpqrsTUVwxyz`)
-4. Paste it when Telecode prompts for `TELEGRAM_BOT_TOKEN`
+Telecode can expose AI tools via the Model Context Protocol, allowing remote agents to access your local AI engines:
 
-### 3. Start Chatting
+### Enable MCP Server
 
-1. Find your bot in Telegram (search for the username you created)
-2. Send `/start` to begin
-3. Send any message to interact with the AI engine
-4. Use `/engine` to check or switch engines
+```bash
+telecode --enable-mcp
+```
 
-## Configuration
+The server will display your MCP connection URL:
+```
++----------------------------------------------------+
+| MCP Server Configuration:                          |
+|                                                    |
+| URL: https://your-tunnel.ngrok-free.app/mcp/      |
+| (Public ngrok URL - share with remote MCP clients)|
+|                                                    |
+| Available Tools:                                   |
+|   - local_claude_code: Execute Claude Code CLI     |
+|   - local_codex: Execute Codex CLI                 |
+|   - local_cli: Execute shell commands              |
++----------------------------------------------------+
+```
 
-### Configuration Files
+### MCP Tools
 
-Telecode reads configuration from two locations (local overrides global):
+- **`local_claude_code`** — Execute prompts with Claude Code CLI
+- **`local_codex`** — Execute prompts with Codex CLI
+- **`local_cli`** — Run shell commands on your server
 
-1. **Global**: `~/.telecode` - User-wide settings
-2. **Local**: `./.telecode` - Project-specific settings
+MCP clients can connect to your server and use these tools remotely. Sessions are independent from Telegram, allowing simultaneous use.
 
-When you run interactive commands (e.g., `/engine claude`), settings are saved to the local config.
+## 💬 Telegram Commands
 
-### Configuration Keys
+| Command | Description |
+|---------|-------------|
+| `/engine` | Show current AI engine |
+| `/claude` | Switch to Claude Code |
+| `/codex` | Switch to Codex |
+| `/cli <cmd>` | Execute shell command |
+| `/tts_on` | Enable TTS audio responses |
+| `/tts_off` | Disable TTS responses |
 
-| Key | Description | Default |
-|-----|-------------|---------|
-| `TELEGRAM_BOT_TOKEN` | Bot token from @BotFather | *Required* |
-| `TELEGRAM_TUNNEL_URL` | Public tunnel URL (e.g., `https://xxxx.ngrok-free.app`) | Auto-generated via ngrok |
-| `TELEGRAM_WEBHOOK_SECRET` | Webhook security secret | Auto-generated on startup |
-| `TELECODE_ENGINE` | Default engine: `claude` or `codex` | `claude` |
-| `TELECODE_HOST` | Server bind address | `0.0.0.0` |
-| `TELECODE_PORT` | Server port | `8000` |
-| `TELECODE_ALLOWED_USERS` | Comma/space-separated user IDs or `@usernames` | *(empty = allow all)* |
-| `TELECODE_VERBOSE` | Enable verbose logging: `1` or `0` | `0` |
-| `TELECODE_NGROK` | Auto-start ngrok: `1` or `0` | `1` |
-| `TELECODE_TTS` | Enable TTS responses: `1` or `0` | `0` |
-| `NGROK_AUTHTOKEN` | ngrok authentication token | *(required for ngrok)* |
-| `TTS_TOKEN` | Fish Audio API token | *(required for TTS)* |
-| `TTS_MODEL` | Fish Audio model | `s1` |
-| `CLAUDE_TIMEOUT_S` | Claude command timeout in seconds | `None` |
-| `TELECODE_SESSION_CLAUDE` | Stored session ID for Claude | Auto-managed |
-| `TELECODE_SESSION_CODEX` | Stored session ID for Codex | Auto-managed |
-| `TELECODE_ENGINE_OVERRIDE_<chat_id>` | Per-chat engine override | Auto-managed |
+## 🎯 Usage Examples
 
-### Example Configuration
+### Chat with AI
+Simply send any message to interact with the current engine:
+```
+You: Write a Python function to reverse a string
 
-`.telecode`:
+Bot: Here's a simple function:
+
+def reverse_string(s):
+    return s[::-1]
+```
+
+### Analyze Images
+Send a photo with a caption:
+```
+[Screenshot of error]
+Caption: "What's causing this bug?"
+
+Bot: This is a NullPointerException at line 42...
+```
+
+### Execute Commands
+```
+/cli git status
+
+Bot: On branch main
+     Your branch is up to date...
+```
+
+### Voice Messages
+Hold the mic button, speak your prompt, release. The bot transcribes and responds.
+
+## ⚙️ Configuration
+
+Configuration is stored in `.telecode` (local) or `~/.telecode` (global):
+
 ```bash
 TELEGRAM_BOT_TOKEN=123456789:ABCdefGHIjklMNOpqrsTUVwxyz
-TELEGRAM_TUNNEL_URL=https://abc123.ngrok-free.app
 TELECODE_ENGINE=claude
-TELECODE_ALLOWED_USERS=12345678,@username,987654321
-TELECODE_TTS=1
-TTS_TOKEN=your_fish_audio_token
+TELECODE_ALLOWED_USERS=123456789,@username
+TELECODE_ENABLE_MCP=1
 TELECODE_VERBOSE=1
 ```
 
-## Usage
+### Key Configuration Options
 
-### Telegram Commands
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TELEGRAM_BOT_TOKEN` | Bot token from @BotFather | *Required* |
+| `TELEGRAM_TUNNEL_URL` | Public webhook URL | Auto via ngrok |
+| `TELECODE_ENGINE` | Default engine: `claude` or `codex` | `claude` |
+| `TELECODE_ENABLE_MCP` | Enable MCP server | `0` |
+| `TELECODE_ALLOWED_USERS` | User whitelist (IDs/@usernames) | *(empty = all)* |
+| `TELECODE_VERBOSE` | Enable verbose logging | `0` |
+| `TELECODE_TTS` | Enable TTS responses | `0` |
 
-| Command | Description | Example |
-|---------|-------------|---------|
-| `/engine` | Show current engine | `/engine` |
-| `/engine <name>` | Switch engine | `/engine claude`<br>`/engine codex` |
-| `/claude` | Switch to Claude (shortcut) | `/claude` |
-| `/codex` | Switch to Codex (shortcut) | `/codex` |
-| `/cli <command>` | Run shell command on server | `/cli ls -la`<br>`/cli git status` |
-| `/tts_on` | Enable TTS audio responses | `/tts_on` |
-| `/tts_off` | Disable TTS audio responses | `/tts_off` |
-
-### Text Messages
-
-Simply send any text message to interact with the current AI engine:
-
-```
-You: Write a Python function to calculate fibonacci numbers
-
-Bot: Here's a Python function to calculate Fibonacci numbers:
-
-def fibonacci(n):
-    if n <= 1:
-        return n
-    return fibonacci(n-1) + fibonacci(n-2)
-
-This is a recursive implementation. For better performance
-with larger values, consider using dynamic programming or
-iterative approach.
-```
-
-### Image Processing
-
-Send images to the bot for AI analysis:
-
-1. **Photo**: Send any photo directly
-2. **Document**: Send an image file as a document
-3. **Caption**: Add a caption to specify what you want the AI to analyze
-
-Example:
-```
-[Send screenshot of error message]
-Caption: "What's causing this error?"
-
-Bot: This error is a NullPointerException occurring at line 42...
-```
-
-**How it works**:
-- Images are downloaded to `./.telecode_tmp/`
-- For Claude Code: Images are passed via `--add-dir` flag with file paths
-- For Codex: Images are passed via `--image` flag
-- Original prompt/caption is included with image references
-
-### Voice Messages
-
-Record and send voice messages for hands-free interaction:
-
-1. Hold the microphone button in Telegram
-2. Speak your prompt
-3. Release to send
-
-**Requirements**:
-- `openai-whisper` package installed
-- `ffmpeg` available in system PATH
-
-**How it works**:
-- Voice note is downloaded as `.ogg` audio file
-- Whisper `base` model transcribes the audio
-- Transcribed text is sent to the AI engine
-- Response is sent back as text (and audio if TTS is enabled)
-
-### Text-to-Speech (TTS)
-
-Enable audio responses using Fish Audio API:
-
-1. **Enable TTS**:
-   ```
-   /tts_on
-   ```
-
-2. **Configure Fish Audio Token**:
-   Add to `.telecode`:
-   ```bash
-   TTS_TOKEN=your_fish_audio_api_token
-   TTS_MODEL=s1
-   ```
-
-3. **Get Audio Responses**:
-   Every AI response will be followed by an audio message with the spoken version.
-
-**How it works**:
-- AI response text is cleaned (removes markdown `**` formatting)
-- Text is sent to Fish Audio TTS API
-- Audio file is saved to `./.telecode_tmp/`
-- Audio is sent to Telegram as a voice message
-
-## Tunnel & Webhook
-
-Telegram webhooks require a public HTTPS URL. Telecode supports two approaches:
-
-### Auto-Tunneling with ngrok (Default)
-
-Telecode automatically starts an ngrok tunnel if `TELEGRAM_TUNNEL_URL` is not set:
-
-1. **First-time setup**:
-   - Sign up at [ngrok.com](https://ngrok.com)
-   - Get your auth token from the dashboard
-   - Telecode will prompt for it on first run
-   - Token is saved to `~/.telecode`
-
-2. **Limitations**:
-   - Subject to [ngrok free plan limits](https://ngrok.com/docs/pricing-limits/free-plan-limits)
-   - Tunnel URL changes on each restart
-
-### Manual Tunnel Setup
-
-Disable auto-tunneling and provide your own URL:
-
-```bash
-# Set in .telecode or environment
-TELECODE_NGROK=0
-TELEGRAM_TUNNEL_URL=https://your-domain.com
-```
-
-Or use ngrok manually:
-```bash
-ngrok http 8000
-# Copy the HTTPS URL to TELEGRAM_TUNNEL_URL
-```
-
-### Webhook Security
-
-Telecode generates a fresh webhook secret on each startup:
-```
-Webhook URL: https://xxx.ngrok-free.app/telegram/{secret}
-```
-
-The secret is verified on every incoming request to prevent unauthorized access.
-
-## Access Control
+## 🔐 Access Control
 
 Restrict bot access to specific users:
 
-### By User ID
-
 ```bash
+# By user ID (get from @userinfobot)
 TELECODE_ALLOWED_USERS=123456789,987654321
-```
 
-To find your Telegram user ID:
-- Message [@userinfobot](https://t.me/userinfobot)
-- It will reply with your user ID
-
-### By Username
-
-```bash
+# By username
 TELECODE_ALLOWED_USERS=@alice,@bob
+
+# Mixed
+TELECODE_ALLOWED_USERS=123456789,@alice
 ```
 
-### Mixed
+Leave empty to allow all users.
+
+## 🛠️ Development
 
 ```bash
-TELECODE_ALLOWED_USERS=123456789,@alice,987654321
-```
-
-### Allow All (Default)
-
-Leave `TELECODE_ALLOWED_USERS` empty or unset to allow any user.
-
-## Development
-
-### Setup Development Environment
-
-```bash
-# Clone repository
+# Clone and install
 git clone https://github.com/polinom/telecode.git
 cd telecode
-
-# Create virtual environment
-python3 -m venv .venv
-source .venv/bin/activate  # On Windows: .venv\Scripts\activate
-
-# Install dependencies
-pip install -r requirements.txt
-
-# Install in editable mode
 pip install -e .
-```
 
-### Run with Auto-Reload
+# Run with auto-reload
+telecode --reload -v
 
-```bash
-telecode --reload
-```
-
-### Enable Verbose Logging
-
-```bash
-telecode -v
-```
-
-Or set in configuration:
-```bash
-TELECODE_VERBOSE=1
-```
-
-### Run Tests
-
-```bash
+# Run tests
 pytest -q
 ```
 
-### Project Structure
+### CLI Options
 
-```
-telecode/
-├── telecode/           # Main package
-│   ├── __init__.py
-│   ├── server.py       # FastAPI webhook server
-│   ├── claude.py       # Claude Code engine integration
-│   ├── codex.py        # Codex engine integration
-│   ├── telegram.py     # Telegram API client
-│   └── cli.py          # CLI entry point
-├── tests/              # Test suite
-│   └── test_server_messages.py
-├── .telecode           # Local configuration (git-ignored)
-├── .telecode_tmp/      # Temporary files (git-ignored)
-├── pyproject.toml      # Package metadata
-├── requirements.txt    # Dependencies
-├── README.md           # This file
-└── AGENTS.md           # Developer guidelines
+```bash
+telecode --help
+
+Options:
+  --host HOST          Host to bind (default: 0.0.0.0)
+  --port PORT          Port to bind (default: 8000)
+  --reload             Enable auto-reload (dev mode)
+  --engine {claude,codex}  Default engine
+  --no-ngrok           Disable ngrok auto-start
+  --enable-mcp         Enable MCP server
+  -v, --verbose        Enable verbose logging
 ```
 
-## Troubleshooting
+## 🏗️ Architecture
+
+```
+┌─────────────┐
+│  Telegram   │
+│   Bot API   │
+└──────┬──────┘
+       │ HTTPS
+       ▼
+┌──────────────┐
+│ ngrok Tunnel │
+└──────┬───────┘
+       │
+       ▼
+┌──────────────────┐     ┌─────────────┐
+│  FastAPI Server  │────▶│ MCP Clients │
+│  (Port 8000)     │     └─────────────┘
+└──────┬───────────┘
+       │
+   ┌───┴───┐
+   ▼       ▼
+┌────────┐ ┌───────┐
+│ Claude │ │ Codex │
+└────────┘ └───────┘
+```
+
+## 📚 Documentation
+
+- **[User Guide](https://polinom.github.io/telecode/)** — Website with examples
+- **[CLAUDE.md](CLAUDE.md)** — Developer guide for AI assistants
+- **[GitHub Issues](https://github.com/polinom/telecode/issues)** — Bug reports and feature requests
+
+## 🔧 Troubleshooting
 
 ### Bot doesn't respond
-
-- **Check webhook**: Ensure `TELEGRAM_TUNNEL_URL` is set and accessible
-- **Check logs**: Run with `-v` flag for verbose output
-- **Verify bot token**: Test token with Telegram API
-- **Check user access**: Ensure your user ID is in `TELECODE_ALLOWED_USERS` (if set)
+- Check webhook URL is accessible
+- Run with `-v` for verbose logs
+- Verify bot token with [@userinfobot](https://t.me/userinfobot)
 
 ### Voice messages fail
-
-```
-Error: Whisper is not installed
-```
-
-**Solution**:
 ```bash
 pip install openai-whisper
+brew install ffmpeg  # macOS
 ```
 
-Ensure `ffmpeg` is installed:
-```bash
-ffmpeg -version
-```
-
-### TTS not working
-
-```
-TTS enabled but TTS_TOKEN is missing
-```
-
-**Solution**:
-Add Fish Audio token to `.telecode`:
-```bash
-TTS_TOKEN=your_token_here
-```
+### Invalid bot token error
+The CLI will detect invalid tokens and prompt for a new one automatically.
 
 ### ngrok authentication failed
+Get your auth token from [ngrok.com](https://dashboard.ngrok.com/get-started/your-authtoken) and paste when prompted.
 
-```
-Failed to start ngrok tunnel
-```
+## 📄 License
 
-**Solution**:
-1. Get auth token from [ngrok.com/signup](https://dashboard.ngrok.com/get-started/your-authtoken)
-2. Run telecode and paste the token when prompted
-3. Or add to `~/.telecode`:
-   ```bash
-   NGROK_AUTHTOKEN=your_token_here
-   ```
-
-### Command timeout
-
-```
-Command timed out after 30s
-```
-
-**Solution**:
-Increase timeout in `.telecode`:
-```bash
-CLAUDE_TIMEOUT_S=120
-```
-
-### Session ID conflicts
-
-```
-Claude failed: Session ID is already in use
-```
-
-**Solution**:
-Telecode automatically retries up to 5 times with 2-second delays. If this persists:
-- Wait a few seconds and try again
-- Check if another Telecode instance is using the same session
-
-### Permission denied on /cli
-
-```
-Command failed: Permission denied
-```
-
-**Solution**:
-- Ensure the server process has appropriate permissions
-- Avoid running sensitive commands without proper access control
-- Use `TELECODE_ALLOWED_USERS` to restrict `/cli` access
-
-## License
-
-MIT
+MIT — See [LICENSE](LICENSE) for details.
 
 ---
 
-**Contributing**: Issues and pull requests are welcome on [GitHub](https://github.com/polinom/telecode).
+**Contributing:** Issues and PRs welcome! • **Security:** Never commit tokens or API keys
 
-**Security**: Never expose your bot token or API keys. Use environment variables or config files that are git-ignored.
+**[⭐ Star on GitHub](https://github.com/polinom/telecode)** if you find this useful!

--- a/docs/index.html
+++ b/docs/index.html
@@ -929,8 +929,8 @@
                 </h1>
                 <p class="hero-description">
                     Bridge Telegram with Claude Code and Codex. Execute commands,
-                    analyze images, transcribe voice, and chat with AI—all from
-                    your favorite messenger.
+                    analyze images, transcribe voice, and expose AI tools via MCP—all from
+                    your favorite messenger or remote agents.
                 </p>
                 <div class="hero-buttons">
                     <a href="#install" class="btn btn-primary">
@@ -947,6 +947,10 @@
                     <div class="stat-item">
                         <span class="stat-value">2</span>
                         <span class="stat-label">AI Engines</span>
+                    </div>
+                    <div class="stat-item">
+                        <span class="stat-value">3</span>
+                        <span class="stat-label">MCP Tools</span>
                     </div>
                     <div class="stat-item">
                         <span class="stat-value">5+</span>
@@ -1117,6 +1121,13 @@
                     <div class="feature-content">
                         <h3>Developer Friendly</h3>
                         <p>Verbose logging, auto-reload, and comprehensive configuration. Built for developers.</p>
+                    </div>
+                </div>
+                <div class="feature-item reveal">
+                    <div class="feature-icon">📡</div>
+                    <div class="feature-content">
+                        <h3>MCP Server</h3>
+                        <p>Expose AI tools via Model Context Protocol. Enable remote agent access to your local Claude Code and Codex engines.</p>
                     </div>
                 </div>
             </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telecode"
-version = "0.1.4"
+version = "0.1.5"
 description = "Telegram webhook server that runs Claude Code or Codex in the background"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -17,6 +17,9 @@ dependencies = [
   "httpx>=0.27",
   "python-dotenv>=1.0",
   "ngrok>=0.13.0",
+  "mcp>=1.25.0",
+  "fastmcp>=2.0.0",
+  "websockets<14.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ httpx>=0.27
 python-dotenv>=1.0
 ngrok>=0.13.0
 pytest>=8.0
+mcp>=1.25.0
+fastmcp>=2.0.0
+websockets<14.0

--- a/telecode/cli.py
+++ b/telecode/cli.py
@@ -4,6 +4,7 @@ import os
 import re
 import uuid
 
+import httpx
 import uvicorn
 
 from telecode.telegram import (
@@ -164,6 +165,16 @@ def _store_global_env_value(key: str, value: str) -> None:
     _write_env_lines(env_path, lines)
 
 
+def _extract_ngrok_error_message(exc: Exception) -> str:
+    """Extract readable error message from ngrok exception."""
+    exc_str = str(exc)
+    # ngrok ValueError is a tuple: ('error_type', 'message', 'error_code')
+    if isinstance(exc.args, tuple) and len(exc.args) >= 2:
+        # Second element is the detailed message
+        return exc.args[1] if isinstance(exc.args[1], str) else exc_str
+    return exc_str
+
+
 def _ensure_tunnel_url(disable_ngrok: bool) -> str | None:
     current = os.getenv("TELEGRAM_TUNNEL_URL")
     if current:
@@ -174,12 +185,44 @@ def _ensure_tunnel_url(disable_ngrok: bool) -> str | None:
         try:
             public_url = _start_ngrok_tunnel(port)
         except ValueError as exc:
-            token = _prompt_ngrok_authtoken(str(exc))
-            if token:
-                _store_global_env_value("NGROK_AUTHTOKEN", token)
-                os.environ["NGROK_AUTHTOKEN"] = token
-                public_url = _start_ngrok_tunnel(port)
+            error_msg = _extract_ngrok_error_message(exc)
+            # Check if it's an auth token error
+            if "authtoken" in error_msg.lower() or "authentication" in error_msg.lower():
+                token = _prompt_ngrok_authtoken(error_msg)
+                if token:
+                    _store_global_env_value("NGROK_AUTHTOKEN", token)
+                    os.environ["NGROK_AUTHTOKEN"] = token
+                    try:
+                        public_url = _start_ngrok_tunnel(port)
+                    except ValueError as retry_exc:
+                        retry_error_msg = _extract_ngrok_error_message(retry_exc)
+                        _print_boxed_message([
+                            "Failed to start ngrok tunnel after setting auth token.",
+                            "",
+                            "Error details:",
+                            retry_error_msg,
+                            "",
+                            "Please:",
+                            "1. Check https://dashboard.ngrok.com/agents for active sessions",
+                            "2. Stop other ngrok instances if needed",
+                            "3. Or manually set TELEGRAM_TUNNEL_URL in .telecode",
+                        ])
+                        return None
+                else:
+                    return None
             else:
+                # Other ngrok errors (session limit, network issues, etc.)
+                _print_boxed_message([
+                    "Failed to start ngrok tunnel.",
+                    "",
+                    "Error details:",
+                    error_msg,
+                    "",
+                    "Please:",
+                    "1. Check https://dashboard.ngrok.com/agents for active sessions",
+                    "2. Stop other ngrok instances if needed",
+                    "3. Or manually set TELEGRAM_TUNNEL_URL in .telecode",
+                ])
                 return None
         if public_url:
             os.environ["TELEGRAM_TUNNEL_URL"] = public_url
@@ -297,6 +340,11 @@ def main() -> None:
         action="store_true",
         help="Enable verbose logging",
     )
+    parser.add_argument(
+        "--enable-mcp",
+        action="store_true",
+        help="Enable MCP server for exposing tools to other agents",
+    )
 
     args = parser.parse_args()
 
@@ -307,6 +355,8 @@ def main() -> None:
     os.environ["TELECODE_PORT"] = str(args.port)
     if args.verbose:
         os.environ["TELECODE_VERBOSE"] = "1"
+    if args.enable_mcp:
+        os.environ["TELECODE_ENABLE_MCP"] = "1"
 
     bot_token = _ensure_bot_token()
     tunnel_url = _ensure_tunnel_url(args.no_ngrok)
@@ -315,6 +365,47 @@ def main() -> None:
     if bot_token:
         try:
             _ensure_bot_commands(bot_token)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                _print_boxed_message([
+                    "Invalid Telegram bot token detected!",
+                    "The token returned 404 Not Found from Telegram API.",
+                    "",
+                    "Please enter a valid bot token from @BotFather.",
+                ])
+                new_token = input("Enter valid TELEGRAM_BOT_TOKEN: ").strip()
+                if new_token:
+                    # Determine which config file to update
+                    local_path = _local_config_path()
+                    global_path = _global_config_path()
+
+                    # Check which file has the token
+                    if os.path.exists(local_path):
+                        config_path = local_path
+                    elif os.path.exists(global_path):
+                        config_path = global_path
+                    else:
+                        config_path = local_path  # Default to local
+
+                    # Update the config file
+                    lines = _read_env_lines(config_path)
+                    lines = _set_env_value(lines, "TELEGRAM_BOT_TOKEN", new_token)
+                    _write_env_lines(config_path, lines)
+
+                    # Update environment for this session
+                    os.environ["TELEGRAM_BOT_TOKEN"] = new_token
+                    bot_token = new_token
+
+                    # Retry with new token
+                    try:
+                        _ensure_bot_commands(bot_token)
+                        print("✓ Bot token validated successfully!")
+                    except Exception as retry_exc:
+                        print(f"Warning: failed to register bot commands with new token: {retry_exc}")
+                else:
+                    print("No token provided, continuing with invalid token...")
+            else:
+                print(f"Warning: failed to register bot commands: {exc}")
         except Exception as exc:
             print(f"Warning: failed to register bot commands: {exc}")
     if bot_token and tunnel_url:
@@ -326,14 +417,48 @@ def main() -> None:
         except Exception as exc:
             print(f"Warning: failed to set Telegram webhook: {exc}")
 
+    if os.getenv("TELECODE_ENABLE_MCP", "").strip().lower() in {"1", "true", "yes"}:
+        from telecode.mcp_server import get_mcp_connection_config
+
+        # Use ngrok/tunnel URL if available, otherwise use local host:port
+        if tunnel_url:
+            mcp_base_url = tunnel_url.rstrip('/')
+            mcp_url = f"{mcp_base_url}/mcp/"
+            connection_note = "(Public ngrok URL - share with remote MCP clients)"
+        else:
+            mcp_config = get_mcp_connection_config(args.host, args.port)
+            mcp_url = mcp_config['http_url']
+            connection_note = f"(Local only - port {args.port})"
+
+        _print_boxed_message([
+            "MCP Server Configuration:",
+            "",
+            f"URL: {mcp_url}",
+            connection_note,
+            "",
+            "Available Tools:",
+            "  - local_claude_code: Execute Claude Code CLI",
+            "  - local_codex: Execute Codex CLI",
+            "  - local_cli: Execute shell commands",
+            "",
+            "Copy this URL to connect from other MCP clients",
+        ])
+
     _print_command_help()
+
+    # Set log level based on verbose flag
+    log_level = "info" if args.verbose else "warning"
+
+    if args.verbose:
+        print(f"Starting server with log_level={log_level}")
 
     uvicorn.run(
         "telecode.server:app",
         host=args.host,
         port=args.port,
         reload=args.reload,
-        log_level="warning",
+        log_level=log_level,
+        access_log=args.verbose,  # Enable access logs when verbose
     )
 
 

--- a/telecode/mcp_server.py
+++ b/telecode/mcp_server.py
@@ -1,0 +1,286 @@
+import os
+import subprocess
+import threading
+import traceback
+import uuid
+from typing import Optional
+
+from fastmcp import FastMCP
+
+from telecode.claude import ask_claude_code
+from telecode.codex import ask_codex_exec
+
+
+# In-memory session storage (independent from Telegram sessions)
+_MCP_SESSIONS: dict[str, dict[str, str]] = {}
+_MCP_SESSION_LOCK = threading.Lock()
+
+
+def _is_verbose() -> bool:
+    """Check if verbose logging is enabled."""
+    value = os.getenv("TELECODE_VERBOSE", "").strip().lower()
+    return value in {"1", "true", "yes", "on", "verbose", "debug"}
+
+
+def _get_mcp_session(client_id: str, engine: str) -> Optional[str]:
+    """Retrieve MCP session ID for a client and engine.
+
+    Args:
+        client_id: MCP client identifier
+        engine: AI engine name ("claude" or "codex")
+
+    Returns:
+        Session ID if exists, None otherwise
+    """
+    with _MCP_SESSION_LOCK:
+        return _MCP_SESSIONS.get(client_id, {}).get(engine)
+
+
+def _set_mcp_session(client_id: str, engine: str, session_id: str) -> None:
+    """Store MCP session ID for a client and engine.
+
+    Args:
+        client_id: MCP client identifier
+        engine: AI engine name ("claude" or "codex")
+        session_id: Session ID to store
+    """
+    with _MCP_SESSION_LOCK:
+        if client_id not in _MCP_SESSIONS:
+            _MCP_SESSIONS[client_id] = {}
+        _MCP_SESSIONS[client_id][engine] = session_id
+
+
+def _get_or_create_mcp_session(engine: str) -> str:
+    """Get or create a session for MCP requests.
+
+    Uses a global MCP client ID since we can't reliably track individual clients.
+
+    Args:
+        engine: AI engine name ("claude" or "codex")
+
+    Returns:
+        Session ID (existing or newly created)
+    """
+    client_id = "mcp_global"
+    session_id = _get_mcp_session(client_id, engine)
+
+    if not session_id:
+        session_id = str(uuid.uuid4())
+        _set_mcp_session(client_id, engine, session_id)
+
+    return session_id
+
+
+def _truncate_message(text: str, limit: int = 3500) -> str:
+    """Truncate message to limit with indicator.
+
+    Args:
+        text: Text to truncate
+        limit: Character limit
+
+    Returns:
+        Truncated text with indicator if needed
+    """
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]}\n...[truncated]"
+
+
+# Initialize FastMCP server
+mcp = FastMCP("Telecode MCP Server")
+
+
+@mcp.tool()
+def local_claude_code(
+    prompt: str,
+    session_id: Optional[str] = None,
+    timeout_s: Optional[int] = None,
+    image_paths: Optional[list[str]] = None
+) -> str:
+    """Execute a prompt using Claude Code CLI.
+
+    Args:
+        prompt: The prompt to send to Claude Code
+        session_id: Optional session ID for conversation continuity
+        timeout_s: Optional timeout in seconds
+        image_paths: Optional list of image file paths to include
+
+    Returns:
+        Claude Code response as string, or error message
+    """
+    try:
+        # Get or create session if not provided
+        effective_session_id = session_id or _get_or_create_mcp_session("claude")
+
+        # Execute with existing function (reuses _CLAUDE_LOCK for thread safety)
+        result = ask_claude_code(
+            prompt=prompt,
+            session_id=effective_session_id,
+            timeout_s=timeout_s,
+            image_paths=image_paths
+        )
+
+        # Store session for future requests
+        if not session_id:
+            _set_mcp_session("mcp_global", "claude", effective_session_id)
+
+        return result
+
+    except subprocess.TimeoutExpired as exc:
+        return f"Error: Command timed out after {timeout_s}s"
+    except RuntimeError as exc:
+        # Claude-specific errors (session in use, not found, etc.)
+        return f"Error: {exc}"
+    except Exception as exc:
+        # Unexpected errors
+        if _is_verbose():
+            traceback.print_exc()
+        return f"Unexpected error: {type(exc).__name__}: {exc}"
+
+
+@mcp.tool()
+def local_codex(
+    prompt: str,
+    session_id: Optional[str] = None,
+    timeout_s: Optional[int] = None,
+    image_paths: Optional[list[str]] = None
+) -> dict:
+    """Execute a prompt using Codex CLI.
+
+    Args:
+        prompt: The prompt to send to Codex
+        session_id: Optional session ID for conversation continuity
+        timeout_s: Optional timeout in seconds
+        image_paths: Optional list of image file paths to include
+
+    Returns:
+        Dictionary with 'answer', 'session_id', and 'logs' keys
+    """
+    try:
+        # Execute with existing function
+        answer, new_session_id, logs = ask_codex_exec(
+            prompt=prompt,
+            session_id=session_id,
+            timeout_s=timeout_s,
+            image_paths=image_paths
+        )
+
+        # Store session if returned
+        if new_session_id:
+            _set_mcp_session("mcp_global", "codex", new_session_id)
+
+        return {
+            "answer": answer,
+            "session_id": new_session_id or session_id or "",
+            "logs": logs
+        }
+
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "answer": f"Error: Command timed out after {timeout_s}s",
+            "session_id": session_id or "",
+            "logs": str(exc)
+        }
+    except RuntimeError as exc:
+        # Codex-specific errors
+        return {
+            "answer": f"Error: {exc}",
+            "session_id": session_id or "",
+            "logs": str(exc)
+        }
+    except Exception as exc:
+        # Unexpected errors
+        if _is_verbose():
+            traceback.print_exc()
+        return {
+            "answer": f"Unexpected error: {type(exc).__name__}: {exc}",
+            "session_id": session_id or "",
+            "logs": traceback.format_exc()
+        }
+
+
+@mcp.tool()
+def local_cli(command: str, timeout_s: int = 30) -> str:
+    """Execute a shell command locally.
+
+    Security Warning:
+        This tool executes arbitrary shell commands. Use with caution.
+
+    Args:
+        command: Shell command to execute
+        timeout_s: Timeout in seconds (default: 30)
+
+    Returns:
+        Command output (stdout + stderr), or error message
+    """
+    try:
+        completed = subprocess.run(
+            command,
+            shell=True,
+            text=True,
+            capture_output=True,
+            timeout=timeout_s,
+            cwd=os.getcwd(),
+        )
+
+        stdout = (completed.stdout or "").strip()
+        stderr = (completed.stderr or "").strip()
+        output = "\n".join(part for part in [stdout, stderr] if part)
+
+        if not output:
+            output = "Command finished with no output."
+
+        return _truncate_message(output)
+
+    except subprocess.TimeoutExpired:
+        return f"Error: Command timed out after {timeout_s}s."
+    except Exception as exc:
+        if _is_verbose():
+            traceback.print_exc()
+        return f"Error: Command failed: {exc}"
+
+
+def create_mcp_app():
+    """Create and configure MCP server app.
+
+    Returns:
+        ASGI app ready for mounting in FastAPI
+    """
+    # FastMCP provides http_app() method to create an ASGI application
+    # Pass path="/" so the MCP endpoints are at the mount root (not /mcp/mcp/)
+    # See: https://gofastmcp.com/integrations/fastapi
+    return mcp.http_app(path="/")
+
+
+def get_mcp_connection_config(host: str, port: int) -> dict:
+    """Generate MCP connection configuration for clients.
+
+    Args:
+        host: Server host address
+        port: Server port number
+
+    Returns:
+        Dictionary with connection URLs and tool information
+    """
+    base_url = f"http://{host}:{port}"
+
+    return {
+        "name": "Telecode MCP Server",
+        "version": "1.0",
+        "sse_url": f"{base_url}/mcp/sse",
+        "http_url": f"{base_url}/mcp/",
+        "tools": [
+            {
+                "name": "local_claude_code",
+                "description": "Execute prompts with Claude Code CLI"
+            },
+            {
+                "name": "local_codex",
+                "description": "Execute prompts with Codex CLI"
+            },
+            {
+                "name": "local_cli",
+                "description": "Execute shell commands"
+            }
+        ]
+    }

--- a/telecode/server.py
+++ b/telecode/server.py
@@ -14,7 +14,10 @@ from typing import Optional
 from contextlib import asynccontextmanager
 
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
 from dotenv import load_dotenv
+import time
 
 from telecode.claude import ask_claude_code
 from telecode.codex import ask_codex_exec
@@ -37,10 +40,77 @@ async def _lifespan(app: FastAPI):
         _ensure_bot_commands(telegram)
     except Exception as exc:
         print(f"Warning: failed to register bot commands: {exc}")
+
+    # Mount MCP server if enabled
+    mcp_app = None
+    mcp_lifespan_context = None
+    if os.getenv("TELECODE_ENABLE_MCP", "").strip().lower() in {"1", "true", "yes"}:
+        try:
+            from telecode.mcp_server import create_mcp_app
+            mcp_app = create_mcp_app()
+            print(f"  MCP app type: {type(mcp_app).__name__}")
+
+            # Enter the MCP app's lifespan context
+            if hasattr(mcp_app, 'lifespan'):
+                mcp_lifespan_context = mcp_app.lifespan(mcp_app)
+                await mcp_lifespan_context.__aenter__()
+
+            app.mount("/mcp", mcp_app)
+            print("✓ MCP server mounted at /mcp")
+            print("  MCP protocol endpoints available")
+            print("  Use MCP clients to connect to the tools")
+        except Exception as exc:
+            print(f"✗ Warning: failed to mount MCP server: {exc}")
+            import traceback
+            traceback.print_exc()
+
     yield
+
+    # Exit the MCP app's lifespan context on shutdown
+    if mcp_lifespan_context is not None:
+        try:
+            await mcp_lifespan_context.__aexit__(None, None, None)
+        except Exception as exc:
+            print(f"Warning: error shutting down MCP server: {exc}")
 
 
 app = FastAPI(lifespan=_lifespan)
+
+# Logging middleware to see all requests (including to mounted apps)
+class LoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        # Always log in verbose mode (check each time since it's per-request)
+        verbose = os.getenv("TELECODE_VERBOSE", "").strip().lower() in {"1", "true", "yes", "on", "verbose", "debug"}
+
+        if verbose:
+            start_time = time.time()
+            print(f"→ {request.method} {request.url.path} from {request.client.host if request.client else 'unknown'}")
+
+        response = await call_next(request)
+
+        if verbose:
+            duration = time.time() - start_time
+            print(f"← {request.method} {request.url.path} → {response.status_code} ({duration:.3f}s)")
+
+        return response
+
+# Add logging middleware first (so it captures all requests)
+app.add_middleware(LoggingMiddleware)
+
+# Debug: Print on startup to verify verbose mode
+verbose_env = os.getenv("TELECODE_VERBOSE", "NOT SET")
+print(f"Debug: TELECODE_VERBOSE = {verbose_env}")
+print(f"Debug: Verbose logging = {'ENABLED' if verbose_env in {'1', 'true', 'yes', 'on', 'verbose', 'debug'} else 'DISABLED'}")
+
+# Add CORS middleware for MCP clients
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],  # Allow all origins for MCP clients
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 _SESSION_LOCKS: dict[str, threading.Lock] = {}
 _SESSION_LOCKS_GUARD = threading.Lock()
 _SESSIONS_FILE_GUARD = threading.Lock()
@@ -276,6 +346,18 @@ def _handle_cli_command(
 @app.get("/health")
 async def health() -> dict[str, bool]:
     return {"ok": True}
+
+
+@app.get("/mcp-test")
+async def mcp_test() -> dict:
+    """Test endpoint to verify MCP server is accessible."""
+    mcp_enabled = os.getenv("TELECODE_ENABLE_MCP", "").strip().lower() in {"1", "true", "yes"}
+    return {
+        "status": "ok",
+        "mcp_enabled": mcp_enabled,
+        "message": "If you see this, the server is reachable through ngrok",
+        "note": "MCP clients connect to /mcp/ (not this endpoint)"
+    }
 
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,248 @@
+import subprocess
+import pytest
+
+
+def test_mcp_server_initialization():
+    """Test MCP server can be created."""
+    from telecode.mcp_server import create_mcp_app
+    app = create_mcp_app()
+    assert app is not None
+
+
+def test_mcp_connection_config():
+    """Test connection config generation."""
+    from telecode.mcp_server import get_mcp_connection_config
+    config = get_mcp_connection_config("localhost", 8000)
+    assert "sse_url" in config
+    assert "http_url" in config
+    assert "tools" in config
+    assert len(config["tools"]) == 3
+    assert config["http_url"] == "http://localhost:8000/mcp/"
+    assert config["sse_url"] == "http://localhost:8000/mcp/sse"
+
+
+def test_session_management():
+    """Test MCP session storage and retrieval."""
+    from telecode.mcp_server import _get_mcp_session, _set_mcp_session, _MCP_SESSIONS
+
+    # Clear any existing sessions
+    _MCP_SESSIONS.clear()
+
+    # Initially no session
+    assert _get_mcp_session("client1", "claude") is None
+
+    # Set session
+    _set_mcp_session("client1", "claude", "session-abc")
+
+    # Retrieve session
+    assert _get_mcp_session("client1", "claude") == "session-abc"
+
+    # Different client
+    assert _get_mcp_session("client2", "claude") is None
+
+    # Different engine for same client
+    assert _get_mcp_session("client1", "codex") is None
+
+    # Set another session
+    _set_mcp_session("client1", "codex", "session-xyz")
+    assert _get_mcp_session("client1", "codex") == "session-xyz"
+
+    # Original session still exists
+    assert _get_mcp_session("client1", "claude") == "session-abc"
+
+
+def test_get_or_create_mcp_session():
+    """Test session creation on first request."""
+    from telecode.mcp_server import _get_or_create_mcp_session, _MCP_SESSIONS
+
+    _MCP_SESSIONS.clear()
+
+    # First call creates session
+    session_id = _get_or_create_mcp_session("claude")
+    assert session_id is not None
+    assert len(session_id) > 0
+
+    # Second call returns same session
+    session_id_2 = _get_or_create_mcp_session("claude")
+    assert session_id_2 == session_id
+
+
+def test_local_cli_tool(monkeypatch):
+    """Test CLI tool execution."""
+    class MockResult:
+        stdout = "test output"
+        stderr = ""
+        returncode = 0
+
+    def mock_run(cmd, **kwargs):
+        return MockResult()
+
+    monkeypatch.setattr("subprocess.run", mock_run)
+
+    from telecode.mcp_server import local_cli
+    result = local_cli("echo test")
+    assert "test output" in result
+
+
+def test_local_cli_tool_timeout(monkeypatch):
+    """Test CLI tool handles timeout gracefully."""
+    def mock_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, 10)
+
+    monkeypatch.setattr("subprocess.run", mock_run)
+
+    from telecode.mcp_server import local_cli
+    result = local_cli("sleep 100", timeout_s=10)
+    assert "timed out" in result.lower()
+
+
+def test_local_cli_tool_error(monkeypatch):
+    """Test CLI tool handles subprocess errors."""
+    def mock_run(cmd, **kwargs):
+        raise Exception("command failed")
+
+    monkeypatch.setattr("subprocess.run", mock_run)
+
+    from telecode.mcp_server import local_cli
+    result = local_cli("invalid_command")
+    assert "error" in result.lower() or "failed" in result.lower()
+
+
+def test_local_claude_code_tool(monkeypatch):
+    """Test Claude Code tool execution."""
+    def mock_ask_claude_code(prompt, session_id, timeout_s, image_paths):
+        return "Mocked Claude response"
+
+    monkeypatch.setattr("telecode.mcp_server.ask_claude_code", mock_ask_claude_code)
+
+    from telecode.mcp_server import local_claude_code, _MCP_SESSIONS
+    _MCP_SESSIONS.clear()
+
+    result = local_claude_code("test prompt")
+    assert result == "Mocked Claude response"
+
+
+def test_local_claude_code_tool_with_session(monkeypatch):
+    """Test Claude Code tool with explicit session."""
+    def mock_ask_claude_code(prompt, session_id, timeout_s, image_paths):
+        assert session_id == "my-session-123"
+        return "Mocked Claude response"
+
+    monkeypatch.setattr("telecode.mcp_server.ask_claude_code", mock_ask_claude_code)
+
+    from telecode.mcp_server import local_claude_code
+    result = local_claude_code("test prompt", session_id="my-session-123")
+    assert result == "Mocked Claude response"
+
+
+def test_local_claude_code_tool_timeout_error(monkeypatch):
+    """Test Claude Code tool handles timeout gracefully."""
+    def mock_ask_claude_code(*args, **kwargs):
+        raise subprocess.TimeoutExpired("cmd", 10)
+
+    monkeypatch.setattr("telecode.mcp_server.ask_claude_code", mock_ask_claude_code)
+
+    from telecode.mcp_server import local_claude_code
+    result = local_claude_code("test", timeout_s=10)
+    assert "timed out" in result.lower()
+
+
+def test_local_claude_code_tool_runtime_error(monkeypatch):
+    """Test Claude Code tool handles RuntimeError gracefully."""
+    def mock_ask_claude_code(*args, **kwargs):
+        raise RuntimeError("Session not found")
+
+    monkeypatch.setattr("telecode.mcp_server.ask_claude_code", mock_ask_claude_code)
+
+    from telecode.mcp_server import local_claude_code
+    result = local_claude_code("test")
+    assert "error" in result.lower()
+    assert "session not found" in result.lower()
+
+
+def test_local_codex_tool(monkeypatch):
+    """Test Codex tool execution."""
+    def mock_ask_codex_exec(prompt, session_id, timeout_s, image_paths):
+        return ("Mocked answer", "session-123", "logs")
+
+    monkeypatch.setattr("telecode.mcp_server.ask_codex_exec", mock_ask_codex_exec)
+
+    from telecode.mcp_server import local_codex, _MCP_SESSIONS
+    _MCP_SESSIONS.clear()
+
+    result = local_codex("test prompt")
+    assert isinstance(result, dict)
+    assert result["answer"] == "Mocked answer"
+    assert result["session_id"] == "session-123"
+    assert result["logs"] == "logs"
+
+
+def test_local_codex_tool_with_session(monkeypatch):
+    """Test Codex tool with explicit session."""
+    def mock_ask_codex_exec(prompt, session_id, timeout_s, image_paths):
+        assert session_id == "my-session-456"
+        return ("Mocked answer", "my-session-456", "logs")
+
+    monkeypatch.setattr("telecode.mcp_server.ask_codex_exec", mock_ask_codex_exec)
+
+    from telecode.mcp_server import local_codex
+    result = local_codex("test prompt", session_id="my-session-456")
+    assert result["session_id"] == "my-session-456"
+
+
+def test_local_codex_tool_timeout_error(monkeypatch):
+    """Test Codex tool handles timeout gracefully."""
+    def mock_ask_codex_exec(*args, **kwargs):
+        raise subprocess.TimeoutExpired("cmd", 10)
+
+    monkeypatch.setattr("telecode.mcp_server.ask_codex_exec", mock_ask_codex_exec)
+
+    from telecode.mcp_server import local_codex
+    result = local_codex("test", timeout_s=10)
+    assert isinstance(result, dict)
+    assert "timed out" in result["answer"].lower()
+
+
+def test_local_codex_tool_runtime_error(monkeypatch):
+    """Test Codex tool handles RuntimeError gracefully."""
+    def mock_ask_codex_exec(*args, **kwargs):
+        raise RuntimeError("Codex failed")
+
+    monkeypatch.setattr("telecode.mcp_server.ask_codex_exec", mock_ask_codex_exec)
+
+    from telecode.mcp_server import local_codex
+    result = local_codex("test")
+    assert isinstance(result, dict)
+    assert "error" in result["answer"].lower()
+    assert "codex failed" in result["answer"].lower()
+
+
+def test_truncate_message():
+    """Test message truncation."""
+    from telecode.mcp_server import _truncate_message
+
+    # Short message not truncated
+    short = "This is short"
+    assert _truncate_message(short) == short
+
+    # Long message truncated
+    long = "x" * 4000
+    truncated = _truncate_message(long, limit=3500)
+    assert len(truncated) < len(long)
+    assert "[truncated]" in truncated
+
+
+def test_session_isolation_from_telegram():
+    """Test MCP sessions don't interfere with Telegram."""
+    from telecode.mcp_server import _set_mcp_session, _get_mcp_session, _MCP_SESSIONS
+
+    _MCP_SESSIONS.clear()
+
+    # Set MCP session
+    _set_mcp_session("mcp_client", "claude", "mcp-session-1")
+
+    # Verify MCP session exists
+    assert _get_mcp_session("mcp_client", "claude") == "mcp-session-1"
+
+    # Verify it's in the MCP storage
+    assert "mcp-session-1" in str(_MCP_SESSIONS.values())


### PR DESCRIPTION
## Summary
- Add Model Context Protocol (MCP) server support with three tools for remote agent access
- Improve invalid bot token detection and recovery
- Make documentation more concise and user-friendly

## New Features
- **MCP Server Support**: Enable with `--enable-mcp` flag
- **Three MCP Tools**: `local_claude_code`, `local_codex`, `local_cli`
- **Independent Sessions**: MCP sessions are separate from Telegram conversations
- **Invalid Token Recovery**: Auto-detect 404 errors and prompt for new token

## Documentation Improvements
- Reduced README.md by 60% while maintaining all essential information
- Added prominent MCP feature documentation
- Updated website (docs/index.html) with MCP feature card
- Added comprehensive MCP testing documentation in CLAUDE.md

## Dependencies Added
- mcp>=1.25.0
- fastmcp>=2.0.0
- websockets<14.0

## Files Changed
- **New**: telecode/mcp_server.py, tests/test_mcp_server.py
- **Modified**: telecode/cli.py, telecode/server.py, README.md, docs/index.html, pyproject.toml (v0.1.5)

## Test Plan
- [x] Unit tests for MCP server tools
- [x] Invalid token detection and recovery
- [x] Documentation accuracy
- [ ] Manual testing of MCP endpoint
- [ ] Manual testing of Telegram bot with new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)